### PR TITLE
fix: restrict message events to participants

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -156,6 +156,7 @@ io.on('connection', (socket) => {
 
 // Make io available to routes
 app.set('io', io);
+app.set('userSockets', userSockets);
 
 // Error handling middleware
 app.use((err, req, res, next) => {


### PR DESCRIPTION
## Summary
- expose socket registry to routes
- emit message events only to sender and receiver

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68983c9abd8c8327a5d8a05a790e53d7


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.

## Summary by Sourcery

Expose per-user socket registry and update message routes to emit real-time events only to the sender and receiver instead of broadcasting to all clients

Bug Fixes:
- Restrict all real-time message events (new, edited, deleted, reaction added/removed) to only the sender and receiver sockets rather than using global broadcasts

Enhancements:
- Expose userSockets registry on the Express app for accessing individual user sockets in routes