### PR TITLE
Add validation tests for email and password

### DIFF
--- a/server/middleware/__tests__/validation.test.js
+++ b/server/middleware/__tests__/validation.test.js
@@ -11,6 +11,28 @@ describe('validateEmail', () => {
     const result = validateEmail('user@example.com');
     expect(result.isValid).toBe(true);
   });
+
+  test('rejects empty string', () => {
+    const result = validateEmail('');
+    expect(result.isValid).toBe(false);
+    expect(result.message).toBe('Please provide a valid email address');
+  });
+
+  test('accepts email with subdomain', () => {
+    const result = validateEmail('user@mail.example.com');
+    expect(result.isValid).toBe(true);
+  });
+
+  test('accepts email with special characters', () => {
+    const result = validateEmail('user+tag@example.com');
+    expect(result.isValid).toBe(true);
+  });
+
+  test('rejects email with leading/trailing whitespace', () => {
+    const result = validateEmail('  user@example.com  ');
+    expect(result.isValid).toBe(false);
+    expect(result.message).toBe('Please provide a valid email address');
+  });
 });
 
 describe('validatePassword', () => {

--- a/server/middleware/__tests__/validation.test.js
+++ b/server/middleware/__tests__/validation.test.js
@@ -34,8 +34,9 @@ describe('validateEmail', () => {
     expect(result.message).toBe('Please provide a valid email address');
   });
 });
-
-describe('validatePassword', () => {
+    expect(result.isValid).toBe(true);
+    expect(result.message).toBeUndefined();
+  });
   test('rejects too short password', () => {
     const result = validatePassword('12345');
     expect(result.isValid).toBe(false);

--- a/server/middleware/__tests__/validation.test.js
+++ b/server/middleware/__tests__/validation.test.js
@@ -1,0 +1,39 @@
+const { validateEmail, validatePassword } = require('../validation');
+
+describe('validateEmail', () => {
+  test('rejects malformed email', () => {
+    const result = validateEmail('invalid-email');
+    expect(result.isValid).toBe(false);
+    expect(result.message).toBe('Please provide a valid email address');
+  });
+
+  test('accepts valid email', () => {
+    const result = validateEmail('user@example.com');
+    expect(result.isValid).toBe(true);
+  });
+});
+
+describe('validatePassword', () => {
+  test('rejects too short password', () => {
+    const result = validatePassword('12345');
+    expect(result.isValid).toBe(false);
+    expect(result.message).toBe('Password must be at least 6 characters long');
+  });
+
+  test('rejects password without numbers', () => {
+    const result = validatePassword('abcdef');
+    expect(result.isValid).toBe(false);
+    expect(result.message).toBe('Password must contain at least one letter and one number');
+  });
+
+  test('rejects password without letters', () => {
+    const result = validatePassword('123456');
+    expect(result.isValid).toBe(false);
+    expect(result.message).toBe('Password must contain at least one letter and one number');
+  });
+
+  test('accepts strong password', () => {
+    const result = validatePassword('abc123');
+    expect(result.isValid).toBe(true);
+  });
+});

--- a/server/middleware/__tests__/validation.test.js
+++ b/server/middleware/__tests__/validation.test.js
@@ -1,4 +1,4 @@
-const { validateEmail, validatePassword } = require('../validation');
+const { validateEmail, validatePassword } = require('../validation.js');
 
 describe('validateEmail', () => {
   test('rejects malformed email', () => {

--- a/server/middleware/__tests__/validation.test.js
+++ b/server/middleware/__tests__/validation.test.js
@@ -10,6 +10,7 @@ describe('validateEmail', () => {
   test('accepts valid email', () => {
     const result = validateEmail('user@example.com');
     expect(result.isValid).toBe(true);
+    expect(result.message).toBeUndefined();
   });
 
   test('rejects empty string', () => {


### PR DESCRIPTION
## Summary
- add Jest tests for `validateEmail` to confirm invalid addresses are rejected and valid ones pass
- cover `validatePassword` checks for length, numbers, letters, and valid credentials

## Testing
- `npx jest server/middleware/__tests__/validation.test.js`

------
https://chatgpt.com/codex/tasks/task_b_68983dcf36788327a86c78445dda6b1e


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.

## Summary by Sourcery

Add Jest tests for email and password validation functions

Tests:
- Add tests for validateEmail to reject malformed emails and accept valid ones
- Add tests for validatePassword to enforce minimum length, require both letters and numbers, and accept strong passwords